### PR TITLE
Update README.md  - Update private keys and addresses format

### DIFF
--- a/token/README.md
+++ b/token/README.md
@@ -31,13 +31,13 @@ The `.env` file contains a private key and address. This is the account that wil
 We'll be conducting a transfer between two parties.
 
 ```bash
-The private key and address of Alice.
-private_key: APrivateKey1zkp1w8PTxrRgGfAtfKUSq43iQyVbdQHfhGbiNPEg2LVSEXR
-address: aleo13ssze66adjjkt795z9u5wpq8h6kn0y2657726h4h3e3wfnez4vqsm3008q
+# The private key and address of Alice:
+private_key_Alice="APrivateKey1zkp1w8PTxrRgGfAtfKUSq43iQyVbdQHfhGbiNPEg2LVSEXR"
+address_Alice="aleo13ssze66adjjkt795z9u5wpq8h6kn0y2657726h4h3e3wfnez4vqsm3008q"
 
-The private key and address of Bob.
-private_key: APrivateKey1zkpFo72g7N9iFt3JzzeG8CqsS5doAiXyFvNCgk2oHvjRCzF
-address: aleo17vy26rpdhqx4598y5gp7nvaa9rk7tnvl6ufhvvf4calsrrqdaqyshdsf5z
+# The private key and address of Bob:
+private_key_Bob="APrivateKey1zkpFo72g7N9iFt3JzzeG8CqsS5doAiXyFvNCgk2oHvjRCzF"
+address_Bob="aleo17vy26rpdhqx4598y5gp7nvaa9rk7tnvl6ufhvvf4calsrrqdaqyshdsf5z"
 ```
 
 ## <a id="step0"></a> Public Mint


### PR DESCRIPTION
Update private keys and addresses format

The original format of the private keys and addresses in the README.md file caused issues when copied directly into Git Bash, resulting in errors such as: bash: The: command not found
bash: private_key:: command not found
bash: address:: command not found
bash: The: command not found
bash: private_key:: command not found
bash: address:: command not found

To resolve this, I've adjusted the format to a version that is correctly interpreted by the system. Now, when copied and executed in Git Bash, it works without errors.

Original format:
The private key and address of Alice:
private_key_Alice="APrivateKey1zkp1w8PTxrRgGfAtfKUSq43iQyVbdQHfhGbiNPEg2LVSEXR" address_Alice="aleo13ssze66adjjkt795z9u5wpq8h6kn0y2657726h4h3e3wfnez4vqsm3008q"

The private key and address of Bob:
private_key_Bob="APrivateKey1zkpFo72g7N9iFt3JzzeG8CqsS5doAiXyFvNCgk2oHvjRCzF" address_Bob="aleo17vy26rpdhqx4598y5gp7nvaa9rk7tnvl6ufhvvf4calsrrqdaqyshdsf5z"

Adjusted format:
# The private key and address of Alice:
private_key_Alice="APrivateKey1zkp1w8PTxrRgGfAtfKUSq43iQyVbdQHfhGbiNPEg2LVSEXR" address_Alice="aleo13ssze66adjjkt795z9u5wpq8h6kn0y2657726h4h3e3wfnez4vqsm3008q"

# The private key and address of Bob:
private_key_Bob="APrivateKey1zkpFo72g7N9iFt3JzzeG8CqsS5doAiXyFvNCgk2oHvjRCzF" address_Bob="aleo17vy26rpdhqx4598y5gp7nvaa9rk7tnvl6ufhvvf4calsrrqdaqyshdsf5z"

The changed code is the code on lines 34 and 38